### PR TITLE
Implement Flask phonebook app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install -r requirements.txt
+EXPOSE 8080
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "run:app"]

--- a/README.md
+++ b/README.md
@@ -1,35 +1,40 @@
-# Project Title
+# Yealink Phonebook Server
 
-A short description of the project.
+Deze applicatie biedt een webinterface om een Yealink telefoonboek te beheren. Contacten kunnen worden toegevoegd of verwijderd via de browser en worden opgeslagen in `phonebook.xml` in het Yealink-formaat.
 
-## Table of Contents
-- [Overview](#overview)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Contributing](#contributing)
-- [License](#license)
+## Installatie
 
-## Overview
-Provide a more detailed overview of your project and its goals.
-
-## Installation
-Describe how to install your project and list any prerequisites.
+1. Installeer de vereisten.
 
 ```bash
-# example
-pip install example
+pip install -r requirements.txt
 ```
 
-## Usage
-Give instructions and examples of how to use your project.
+2. Start de applicatie lokaal.
 
 ```bash
-# example
-python app.py --help
+python run.py
 ```
 
-## Contributing
-Explain how others can contribute to your project.
+## Gebruik
 
-## License
-Specify the license for your project.
+Bezoek `http://localhost:8080` voor een lijst van contacten. Gebruik de knop **Nieuwe contact** om een contact toe te voegen. Elk contact heeft een naam, nummer en optioneel label. Wijzigingen worden direct opgeslagen in `phonebook.xml`.
+
+## Docker deployment
+
+De meegeleverde `Dockerfile` bouwt een image dat via Gunicorn op poort 8080 draait. Build en start bijvoorbeeld met:
+
+```bash
+docker build -t phonebook .
+docker run -p 8080:8080 phonebook
+```
+
+Dit is gemakkelijk te deployen via Portainer of de CLI op een Synology NAS.
+
+## Tests
+
+Pytest-tests controleren de logica voor het toevoegen en verwijderen van contacten.
+
+```bash
+pytest
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,15 @@
+from flask import Flask
+from .routes import main_bp
+
+def create_app(test_config=None):
+    app = Flask(__name__)
+    app.config.from_mapping(
+        SECRET_KEY='dev',
+        PHONEBOOK_PATH='phonebook.xml'
+    )
+
+    if test_config:
+        app.config.update(test_config)
+
+    app.register_blueprint(main_bp)
+    return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,52 @@
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def load_phonebook(path):
+    path = Path(path)
+    if not path.exists():
+        root = ET.Element('YealinkIPPhoneDirectory')
+        tree = ET.ElementTree(root)
+        tree.write(path, encoding='utf-8', xml_declaration=True)
+    tree = ET.parse(path)
+    root = tree.getroot()
+    contacts = []
+    for entry in root.findall('DirectoryEntry'):
+        name = entry.findtext('Name')
+        tel_elem = entry.find('Telephone')
+        if tel_elem is not None:
+            tel = tel_elem.text
+            label = tel_elem.get('label', '')
+        else:
+            tel = ''
+            label = ''
+        contacts.append({'name': name, 'telephone': tel, 'label': label})
+    return contacts
+
+
+def save_phonebook(path, contacts):
+    root = ET.Element('YealinkIPPhoneDirectory')
+    for c in contacts:
+        entry = ET.SubElement(root, 'DirectoryEntry')
+        ET.SubElement(entry, 'Name').text = c['name']
+        tel = ET.SubElement(entry, 'Telephone')
+        if c.get('label'):
+            tel.set('label', c['label'])
+        tel.text = c['telephone']
+    tree = ET.ElementTree(root)
+    tree.write(path, encoding='utf-8', xml_declaration=True)
+
+
+def add_contact(path, name, telephone, label=''):
+    contacts = load_phonebook(path)
+    contacts.append({'name': name, 'telephone': telephone, 'label': label})
+    save_phonebook(path, contacts)
+
+
+def delete_contact(path, index):
+    contacts = load_phonebook(path)
+    if 0 <= index < len(contacts):
+        contacts.pop(index)
+        save_phonebook(path, contacts)
+        return True
+    return False

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,28 @@
+from flask import Blueprint, current_app, render_template, request, redirect, url_for
+from .models import load_phonebook, add_contact, delete_contact
+from .utils import validate_contact
+
+main_bp = Blueprint('main', __name__)
+
+@main_bp.route('/')
+def index():
+    contacts = load_phonebook(current_app.config['PHONEBOOK_PATH'])
+    return render_template('index.html', contacts=contacts)
+
+
+@main_bp.route('/add', methods=['GET', 'POST'])
+def add():
+    if request.method == 'POST':
+        name = request.form.get('name')
+        telephone = request.form.get('telephone')
+        label = request.form.get('label', '')
+        if validate_contact(name, telephone):
+            add_contact(current_app.config['PHONEBOOK_PATH'], name, telephone, label)
+            return redirect(url_for('main.index'))
+    return render_template('add.html')
+
+
+@main_bp.route('/delete/<int:index>', methods=['POST'])
+def delete(index):
+    delete_contact(current_app.config['PHONEBOOK_PATH'], index)
+    return redirect(url_for('main.index'))

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,15 @@
+import re
+from flask import flash
+
+PHONE_RE = re.compile(r'^\+?\d{1,15}$')
+
+
+def validate_contact(name, telephone):
+    valid = True
+    if not name:
+        flash('Naam is verplicht.', 'error')
+        valid = False
+    if not telephone or not PHONE_RE.match(telephone):
+        flash('Ongeldig telefoonnummer.', 'error')
+        valid = False
+    return valid

--- a/phonebook.xml
+++ b/phonebook.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<YealinkIPPhoneDirectory/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.0
+Gunicorn
+pytest

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/templates/add.html
+++ b/templates/add.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>Contact toevoegen</title>
+<h1>Nieuw contact</h1>
+<form method="post">
+  Naam: <input type="text" name="name"><br>
+  Nummer: <input type="text" name="telephone"><br>
+  Label: <input type="text" name="label"><br>
+  <button type="submit">Opslaan</button>
+</form>
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    <ul class="flashes">
+    {% for category, message in messages %}
+      <li class="{{ category }}">{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}
+<a href="{{ url_for('main.index') }}">Terug</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>Telefoonboek</title>
+<h1>Contacten</h1>
+<a href="{{ url_for('main.add') }}">Nieuwe contact</a>
+<ul>
+{% for c in contacts %}
+    <li>{{ c.name }} - {{ c.telephone }} ({{ c.label }})
+        <form action="{{ url_for('main.delete', index=loop.index0) }}" method="post" style="display:inline;">
+            <button type="submit">Verwijder</button>
+        </form>
+    </li>
+{% endfor %}
+</ul>
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    <ul class="flashes">
+    {% for category, message in messages %}
+      <li class="{{ category }}">{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}

--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -1,0 +1,22 @@
+import os
+import tempfile
+import pytest
+from app import create_app
+from app import models
+
+@pytest.fixture
+def client():
+    tmpdir = tempfile.TemporaryDirectory()
+    app = create_app({'TESTING': True, 'PHONEBOOK_PATH': os.path.join(tmpdir.name, 'pb.xml'), 'SECRET_KEY': 'test'})
+    with app.test_client() as client:
+        yield client
+    tmpdir.cleanup()
+
+def test_add_and_delete(client):
+    # add contact
+    response = client.post('/add', data={'name': 'John', 'telephone': '+12345', 'label': 'Kantoor'}, follow_redirects=True)
+    assert response.status_code == 200
+    assert b'John' in response.data
+    # delete contact
+    response = client.post('/delete/0', follow_redirects=True)
+    assert b'John' not in response.data


### PR DESCRIPTION
## Summary
- create modular Flask app using blueprints and app factory
- manage Yealink phonebook XML with add/delete
- add minimal UI templates and utils for validation
- include pytest test for add/delete logic
- provide Dockerfile and requirements
- update README with usage and deployment info

## Testing
- `pytest -q` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f52695388832c8b3e219443a3c585