### PR TITLE
Allow spaces in phone numbers

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,9 @@
 import re
 from flask import flash
 
-PHONE_RE = re.compile(r'^\+?\d{1,15}$')
+# Accept phone numbers with optional spaces, e.g. "+31 6 28330622"
+# First check allowed characters (digits, spaces and an optional leading plus)
+PHONE_RE = re.compile(r'^\+?[0-9 ]+$')
 
 
 def validate_contact(name, telephone):
@@ -12,4 +14,9 @@ def validate_contact(name, telephone):
     if not telephone or not PHONE_RE.match(telephone):
         flash('Ongeldig telefoonnummer.', 'error')
         valid = False
+    else:
+        digits = telephone.replace(' ', '').lstrip('+')
+        if not digits.isdigit() or len(digits) > 15:
+            flash('Ongeldig telefoonnummer.', 'error')
+            valid = False
     return valid

--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -14,7 +14,7 @@ def client():
 
 def test_add_and_delete(client):
     # add contact
-    response = client.post('/add', data={'name': 'John', 'telephone': '+12345', 'label': 'Kantoor'}, follow_redirects=True)
+    response = client.post('/add', data={'name': 'John', 'telephone': '+31 6 28330622', 'label': 'Kantoor'}, follow_redirects=True)
     assert response.status_code == 200
     assert b'John' in response.data
     # delete contact
@@ -23,8 +23,8 @@ def test_add_and_delete(client):
 
 
 def test_edit_contact(client):
-    client.post('/add', data={'name': 'Jane', 'telephone': '+67890', 'label': ''})
+    client.post('/add', data={'name': 'Jane', 'telephone': '+31 6 11111111', 'label': ''})
     # edit contact
-    response = client.post('/edit/0', data={'name': 'Janet', 'telephone': '+67890', 'label': 'Priv'}, follow_redirects=True)
+    response = client.post('/edit/0', data={'name': 'Janet', 'telephone': '+31 6 22222222', 'label': 'Priv'}, follow_redirects=True)
     assert response.status_code == 200
     assert b'Janet' in response.data


### PR DESCRIPTION
## Summary
- relax phone number regex to accept spaces
- validate digit count after removing spaces
- adjust tests to use phone numbers with spaces

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687f6118c6e0832c814c40471811ec9a