### PR TITLE
Add CSV import for contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ python run.py
 
 Bezoek `http://localhost:8080` voor een lijst van contacten. Gebruik de knop **Nieuwe contact** om een contact toe te voegen. Elk contact heeft een naam, nummer en optioneel label. Bestaande contacten kun je via de link **Bewerk** aanpassen. Wijzigingen worden direct opgeslagen in `phonebook.xml`.
 
+Via de knop **Importeer CSV** kun je meerdere contacten ineens toevoegen. Upload
+een CSV-bestand met kolommen `name`, `telephone` en optioneel `label`. Alleen
+rijen met geldige waarden worden toegevoegd.
+
 ## Docker Deployment
 
 De meegeleverde `Dockerfile` bouwt een image dat via Gunicorn op poort 8080 draait. Build en start bijvoorbeeld met:

--- a/app/models.py
+++ b/app/models.py
@@ -64,3 +64,26 @@ def update_contact(path, index, name, telephone, label=''):
         save_phonebook(path, contacts)
         return True
     return False
+
+
+def import_contacts(path, fileobj, validator):
+    """Import contacts from a CSV ``fileobj``.
+
+    ``validator`` is a callable like :func:`validate_contact` used to validate
+    each row. Only valid contacts are appended. The function returns the number
+    of successfully imported contacts.
+    """
+    import csv
+    contacts = load_phonebook(path)
+    reader = csv.DictReader(fileobj)
+    added = 0
+    for row in reader:
+        name = row.get('name') or row.get('Name')
+        telephone = row.get('telephone') or row.get('Telephone')
+        label = row.get('label') or row.get('Label') or ''
+        if validator(name, telephone):
+            contacts.append({'name': name, 'telephone': telephone, 'label': label})
+            added += 1
+    if added:
+        save_phonebook(path, contacts)
+    return added

--- a/app/templates/import.html
+++ b/app/templates/import.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block title %}Importeer CSV{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Importeer contacten</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+  <div>
+    <input class="w-full" type="file" name="file" accept=".csv">
+  </div>
+  <button class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600" type="submit">Importeren</button>
+</form>
+<a class="inline-block mt-4 text-blue-500 hover:underline" href="{{ url_for('main.index') }}">Terug</a>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,7 +4,10 @@
 
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Contacten</h1>
-<a class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600" href="{{ url_for('main.add') }}">Nieuwe contact</a>
+<div class="space-x-2">
+  <a class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600" href="{{ url_for('main.add') }}">Nieuwe contact</a>
+  <a class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600" href="{{ url_for('main.import_view') }}">Importeer CSV</a>
+</div>
 <ul class="mt-4 space-y-2">
   {% for c in contacts %}
   <li class="flex justify-between items-center bg-white p-2 rounded shadow">

--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -28,3 +28,13 @@ def test_edit_contact(client):
     response = client.post('/edit/0', data={'name': 'Janet', 'telephone': '+31 6 22222222', 'label': 'Priv'}, follow_redirects=True)
     assert response.status_code == 200
     assert b'Janet' in response.data
+
+
+def test_import_contacts(client):
+    csv_data = "name,telephone,label\nJohn,+31611111111,Kantoor\nJane,+31622222222,Priv"
+    data = {
+        'file': (csv_data.encode('utf-8'), 'contacts.csv'),
+    }
+    response = client.post('/import', data=data, content_type='multipart/form-data', follow_redirects=True)
+    assert response.status_code == 200
+    assert b'John' in response.data and b'Jane' in response.data


### PR DESCRIPTION
## Summary
- enable importing contacts from CSV
- add an `/import` route and template for uploading files
- add link from index page to import
- document import feature in README
- test importing multiple contacts

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f86888c98832c8fef23408fe91772