### PR TITLE
Add Makefile and explain test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test
+
+test:
+	pip install -r requirements.txt
+	pytest

--- a/README.md
+++ b/README.md
@@ -37,8 +37,21 @@ Dit is gemakkelijk te deployen via Portainer of de CLI op een Synology NAS.
 
 ## Tests
 
+
+Voordat je de tests uitvoert moet je eerst de Python-afhankelijkheden installeren:
+
+```bash
+pip install -r requirements.txt
+```
+
 Pytest-tests controleren de logica voor het toevoegen en verwijderen van contacten.
 
 ```bash
 pytest
+```
+
+Je kunt dit ook combineren met de meegeleverde Makefile:
+
+```bash
+make test
 ```


### PR DESCRIPTION
## Summary
- note that tests require installing requirements first
- provide Makefile with a convenient test target

## Testing
- `make test` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f88623524832cb11c923abfc3a3e5