### PR TITLE
Add health check route

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,4 +12,9 @@ def create_app(test_config=None):
         app.config.update(test_config)
 
     app.register_blueprint(main_bp)
+
+    @app.route("/health", methods=["GET"])
+    def health():
+        return "OK", 200
+
     return app


### PR DESCRIPTION
## Summary
- add simple health check route in the Flask factory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687f8a268c50832cb0cd752129580e4e