### PR TITLE
Add docker-compose with healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  phonebook:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./phonebook.xml:/app/phonebook.xml
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with phonebook service that builds from Dockerfile
- expose port 8080 and mount `phonebook.xml` as a volume
- configure healthcheck to call `/health`

## Testing
- `make test` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f8b971ef0832cbe0eeb87edfe9a2d