### PR TITLE
Add health endpoint test

### DIFF
--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -80,3 +80,9 @@ def test_import_with_invalid_rows(client):
     # only valid rows should be imported
     assert b'Valid' in response.data and b'Another' in response.data
     assert b'Bad' not in response.data
+
+
+def test_health_endpoint(client):
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.data == b'OK'


### PR DESCRIPTION
## Summary
- test `/health` endpoint using existing client fixture

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687f8cd868e0832cbdfea93b98abd15d