### PR TITLE
Add XML endpoint test

### DIFF
--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -80,3 +80,11 @@ def test_import_with_invalid_rows(client):
     # only valid rows should be imported
     assert b'Valid' in response.data and b'Another' in response.data
     assert b'Bad' not in response.data
+
+
+def test_phonebook_xml(client):
+    client.post('/add', data={'name': 'XML User', 'telephone': '+31612345678'})
+    response = client.get('/phonebook.xml')
+    assert response.status_code == 200
+    assert response.mimetype == 'application/xml'
+    assert response.data.startswith(b'<?xml')


### PR DESCRIPTION
## Summary
- extend `tests/test_phonebook.py` with a check for `/phonebook.xml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687f8ced20c4832cb2211b083b0e7a6b