### PR TITLE
Fix container healthcheck by adding curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY . /app
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt \
+    && apt-get update \
+    && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
 EXPOSE 8080
 CMD ["gunicorn", "-b", "0.0.0.0:8080", "run:app"]


### PR DESCRIPTION
## Summary
- ensure `curl` is present in the Docker image so the health check works

## Testing
- `make test` *(fails: Could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f9d3ff810832cbe4fd76ae690bd63