### PR TITLE
Ensure phonebook is alphabetical

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -21,12 +21,14 @@ def load_phonebook(path):
             tel = ''
             label = ''
         contacts.append({'name': name, 'telephone': tel, 'label': label})
+    contacts.sort(key=lambda c: c['name'].lower())
     return contacts
 
 
 def save_phonebook(path, contacts):
+    contacts_sorted = sorted(contacts, key=lambda c: c['name'].lower())
     root = ET.Element('YealinkIPPhoneDirectory')
-    for c in contacts:
+    for c in contacts_sorted:
         entry = ET.SubElement(root, 'DirectoryEntry')
         ET.SubElement(entry, 'Name').text = c['name']
         tel = ET.SubElement(entry, 'Telephone')

--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import pytest
 from app import create_app
+from app.models import load_phonebook
 
 @pytest.fixture
 def client():
@@ -22,8 +23,11 @@ def test_add_and_delete(client):
     assert response.status_code == 200
     assert b'Jane' in response.data and b'John' in response.data
 
-    # delete second contact
-    response = client.post('/delete/1', follow_redirects=True)
+    # delete contact "Jane" by finding its sorted index
+    path = client.application.config['PHONEBOOK_PATH']
+    contacts = load_phonebook(path)
+    jane_index = next(i for i, c in enumerate(contacts) if c['name'] == 'Jane')
+    response = client.post(f'/delete/{jane_index}', follow_redirects=True)
     assert b'Jane' not in response.data
     assert b'John' in response.data
 


### PR DESCRIPTION
## Summary
- sort contacts alphabetically when loading and saving
- adapt tests to search for contact index by name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688001d7cf1c832c854b10212eeeac1a