### PR TITLE
Replace warning icon with checkmark

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -53,13 +53,13 @@ document.querySelectorAll('.delete-form').forEach(form => {
   const delBtn = form.querySelector('.delete-btn');
   const cancelBtn = form.querySelector('.cancel-btn');
   const trashIcon = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" />';
-  const warnIcon = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M8.93 4.93l-.707.707a8 8 0 1011.314 11.314l.707-.707A10 10 0 1112 2a10 10 0 00-3.07 8.93z" />';
+  const confirmIcon = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />';
 
   delBtn.addEventListener('click', async (e) => {
     e.preventDefault();
     if (!item.classList.contains('confirming')) {
       item.classList.add('confirming');
-      delBtn.innerHTML = warnIcon;
+      delBtn.innerHTML = confirmIcon;
       delBtn.setAttribute('title', 'Bevestig verwijdering');
       cancelBtn.classList.remove('hidden');
       return;


### PR DESCRIPTION
## Summary
- switch to a checkmark icon when confirming deletion
- rename JS variable to `confirmIcon`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ce169d58832c8571003e8dd237c7