### PR TITLE
Add phonebook xml endpoint test

### DIFF
--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -122,3 +122,13 @@ def test_search_ignores_action_text(client):
     resp = client.get('/')
     matches = _search_items(resp.data.decode('utf-8'), 'b')
     assert len(matches) == 0
+
+
+def test_phonebook_xml(client):
+    """Ensure the phonebook XML is served correctly."""
+    # create at least one contact so the XML has a root element
+    client.post('/add', data={'name': 'Bob', 'telephone': '+31612345678'})
+    response = client.get('/phonebook.xml')
+    assert response.status_code == 200
+    assert response.headers['Content-Type'].startswith('application/xml')
+    assert b'<YealinkIPPhoneDirectory>' in response.data


### PR DESCRIPTION
## Summary
- extend phonebook tests with XML endpoint check

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881061ca094832c8e05d85820764169