### PR TITLE
Add dockerignore to optimize build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Git repository
+.git/
+.gitignore
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+
+# Tests
+tests/
+
+# Other unnecessary files
+phonebook.xml
+docker-compose.yml
+Makefile
+*.md
+.env
+*.log
+*.tmp


### PR DESCRIPTION
## Summary
- Add `.dockerignore` to exclude git data, tests, caches, and other development files from the Docker build context.

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce853945c832c814b057de1d97442