### PR TITLE
test: cover phonebook xml endpoint

### DIFF
--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -122,3 +122,12 @@ def test_search_ignores_action_text(client):
     resp = client.get('/')
     matches = _search_items(resp.data.decode('utf-8'), 'b')
     assert len(matches) == 0
+
+
+def test_phonebook_xml_endpoint(client):
+    path = client.application.config['PHONEBOOK_PATH']
+    load_phonebook(path)
+    response = client.get('/phonebook.xml')
+    assert response.status_code == 200
+    assert response.headers['Content-Type'].startswith('application/xml')
+    assert b'<YealinkIPPhoneDirectory' in response.data


### PR DESCRIPTION
## Summary
- add regression test for the `/phonebook.xml` endpoint verifying status code, content type and XML body

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce84e5420832cb86166a3b8b48385