### PR TITLE
Migrate phonebook to SQLAlchemy

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,19 +1,33 @@
-from flask import Flask, send_file, current_app, Response
+from flask import Flask, Response
 from pathlib import Path
+import xml.etree.ElementTree as ET
+import click
 from .routes import main_bp
+from .models import db, init_db, Contact
 
 def create_app(test_config=None):
     app = Flask(__name__)
-    default_phonebook = Path(__file__).resolve().parents[1] / "phonebook.xml"
+    base_path = Path(__file__).resolve().parents[1]
+    default_phonebook = base_path / "phonebook.xml"
+    default_db = base_path / "phonebook.db"
     app.config.from_mapping(
         SECRET_KEY='dev',
-        PHONEBOOK_PATH=str(default_phonebook)
+        PHONEBOOK_PATH=str(default_phonebook),
+        SQLALCHEMY_DATABASE_URI=f'sqlite:///{default_db}',
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
     )
 
     if test_config:
         app.config.update(test_config)
 
+    db.init_app(app)
     app.register_blueprint(main_bp)
+
+    @app.cli.command("init-db")
+    def init_db_command():
+        """Initialize the database and import contacts from phonebook.xml."""
+        init_db()
+        click.echo("Initialized the database.")
 
     @app.route("/health", methods=["GET"])
     def health():
@@ -21,13 +35,13 @@ def create_app(test_config=None):
 
     @app.route("/phonebook.xml", methods=["GET"])
     def serve_phonebook():
-        """
-        Serve the phonebook XML file from the configured path.
-        """
-        return send_file(
-            current_app.config["PHONEBOOK_PATH"],
-            mimetype="application/xml",
-            as_attachment=False,
-        )
+        contacts = Contact.query.order_by(Contact.name).all()
+        root = ET.Element('YealinkIPPhoneDirectory')
+        for c in contacts:
+            entry = ET.SubElement(root, 'DirectoryEntry')
+            ET.SubElement(entry, 'Name').text = c.name
+            ET.SubElement(entry, 'Telephone').text = c.telephone
+        xml_data = ET.tostring(root, encoding='utf-8', xml_declaration=True)
+        return Response(xml_data, mimetype='application/xml')
 
     return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,82 +1,31 @@
-import xml.etree.ElementTree as ET
+from flask_sqlalchemy import SQLAlchemy
+from flask import current_app
 from pathlib import Path
+import xml.etree.ElementTree as ET
 
 
-def load_phonebook(path):
-    path = Path(path)
+db = SQLAlchemy()
+
+
+class Contact(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    telephone = db.Column(db.String(20), nullable=False)
+
+
+def init_db():
+    """Create all tables and import contacts from phonebook.xml if empty."""
+    db.create_all()
+    if Contact.query.first() is not None:
+        return
+    path = Path(current_app.config["PHONEBOOK_PATH"])
     if not path.exists():
-        root = ET.Element('YealinkIPPhoneDirectory')
-        tree = ET.ElementTree(root)
-        tree.write(path, encoding='utf-8', xml_declaration=True)
+        return
     tree = ET.parse(path)
     root = tree.getroot()
-    contacts = []
     for entry in root.findall('DirectoryEntry'):
         name = entry.findtext('Name')
-        tel_elem = entry.find('Telephone')
-        tel = tel_elem.text if tel_elem is not None else ''
-        contacts.append({'name': name, 'telephone': tel})
-    contacts.sort(key=lambda c: c['name'].lower())
-    return contacts
-
-
-def save_phonebook(path, contacts):
-    contacts_sorted = sorted(contacts, key=lambda c: c['name'].lower())
-    root = ET.Element('YealinkIPPhoneDirectory')
-    for c in contacts_sorted:
-        entry = ET.SubElement(root, 'DirectoryEntry')
-        ET.SubElement(entry, 'Name').text = c['name']
-        tel = ET.SubElement(entry, 'Telephone')
-        tel.text = c['telephone']
-    tree = ET.ElementTree(root)
-    tree.write(path, encoding='utf-8', xml_declaration=True)
-
-
-def add_contact(path, name, telephone):
-    contacts = load_phonebook(path)
-    contacts.append({'name': name, 'telephone': telephone})
-    save_phonebook(path, contacts)
-
-
-def delete_contact(path, index):
-    contacts = load_phonebook(path)
-    if 0 <= index < len(contacts):
-        contacts.pop(index)
-        save_phonebook(path, contacts)
-        return True
-    return False
-
-
-def update_contact(path, index, name, telephone):
-    """Update an existing contact by index."""
-    contacts = load_phonebook(path)
-    if 0 <= index < len(contacts):
-        contacts[index] = {
-            'name': name,
-            'telephone': telephone,
-        }
-        save_phonebook(path, contacts)
-        return True
-    return False
-
-
-def import_contacts(path, fileobj, validator):
-    """Import contacts from a CSV ``fileobj``.
-
-    ``validator`` is a callable like :func:`validate_contact` used to validate
-    each row. Only valid contacts are appended. The function returns the number
-    of successfully imported contacts.
-    """
-    import csv
-    contacts = load_phonebook(path)
-    reader = csv.DictReader(fileobj)
-    added = 0
-    for row in reader:
-        name = row.get('name') or row.get('Name')
-        telephone = row.get('telephone') or row.get('Telephone')
-        if validator(name, telephone):
-            contacts.append({'name': name, 'telephone': telephone})
-            added += 1
-    if added:
-        save_phonebook(path, contacts)
-    return added
+        telephone = entry.findtext('Telephone') or ''
+        if name:
+            db.session.add(Contact(name=name, telephone=telephone))
+    db.session.commit()

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,13 +1,13 @@
-from flask import Blueprint, current_app, render_template, request, redirect, url_for, abort, flash, jsonify
+from flask import Blueprint, render_template, request, redirect, url_for, abort, flash, jsonify
 from io import TextIOWrapper
-from .models import load_phonebook, add_contact, delete_contact, update_contact, import_contacts
+from .models import Contact, db
 from .utils import validate_contact
 
 main_bp = Blueprint('main', __name__)
 
 @main_bp.route('/')
 def index():
-    contacts = load_phonebook(current_app.config['PHONEBOOK_PATH'])
+    contacts = Contact.query.order_by(Contact.name).all()
     return render_template('index.html', contacts=contacts)
 
 
@@ -17,14 +17,20 @@ def add():
         name = request.form.get('name')
         telephone = request.form.get('telephone')
         if validate_contact(name, telephone):
-            add_contact(current_app.config['PHONEBOOK_PATH'], name, telephone)
+            db.session.add(Contact(name=name, telephone=telephone))
+            db.session.commit()
             return redirect(url_for('main.index'))
     return render_template('add.html')
 
 
-@main_bp.route('/delete/<int:index>', methods=['POST', 'DELETE'])
-def delete(index):
-    success = delete_contact(current_app.config['PHONEBOOK_PATH'], index)
+@main_bp.route('/delete/<int:contact_id>', methods=['POST', 'DELETE'])
+def delete(contact_id):
+    contact = Contact.query.get(contact_id)
+    success = False
+    if contact:
+        db.session.delete(contact)
+        db.session.commit()
+        success = True
     if request.method == 'POST':
         return redirect(url_for('main.index'))
     if success:
@@ -32,19 +38,20 @@ def delete(index):
     return jsonify({'error': 'Not found'}), 404
 
 
-@main_bp.route('/edit/<int:index>', methods=['GET', 'POST'])
-def edit(index):
-    contacts = load_phonebook(current_app.config['PHONEBOOK_PATH'])
-    if not (0 <= index < len(contacts)):
+@main_bp.route('/edit/<int:contact_id>', methods=['GET', 'POST'])
+def edit(contact_id):
+    contact = Contact.query.get(contact_id)
+    if contact is None:
         abort(404)
     if request.method == 'POST':
         name = request.form.get('name')
         telephone = request.form.get('telephone')
         if validate_contact(name, telephone):
-            update_contact(current_app.config['PHONEBOOK_PATH'], index, name, telephone)
+            contact.name = name
+            contact.telephone = telephone
+            db.session.commit()
             return redirect(url_for('main.index'))
-    contact = contacts[index]
-    return render_template('edit.html', contact=contact, index=index)
+    return render_template('edit.html', contact=contact)
 
 
 @main_bp.route('/import', methods=['GET', 'POST'])
@@ -53,11 +60,18 @@ def import_view():
         file = request.files.get('file')
         if file:
             text_file = TextIOWrapper(file.stream, encoding='utf-8')
-            count = import_contacts(
-                current_app.config['PHONEBOOK_PATH'], text_file, validate_contact
-            )
-            if count:
-                flash(f"{count} contacten ge\u00efmporteerd.", "info")
+            import csv
+            reader = csv.DictReader(text_file)
+            added = 0
+            for row in reader:
+                name = row.get('name') or row.get('Name')
+                telephone = row.get('telephone') or row.get('Telephone')
+                if validate_contact(name, telephone):
+                    db.session.add(Contact(name=name, telephone=telephone))
+                    added += 1
+            if added:
+                db.session.commit()
+                flash(f"{added} contacten ge\u00efmporteerd.", "info")
             return redirect(url_for('main.index'))
         flash('Geen bestand ge\u00fcppload.', 'error')
     return render_template('import.html')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,12 +20,12 @@
 
   <div id="contact-list" class="divide-y divide-gray-200 bg-white rounded-lg overflow-hidden border border-gray-100">
   {% for c in contacts %}
-  <div class="contact-item fade-slide flex items-center px-6 py-4" data-index="{{ loop.index0 }}">
+  <div class="contact-item fade-slide flex items-center px-6 py-4" data-id="{{ c.id }}">
     <span class="contact-name flex-1 text-xl font-medium text-gray-900">{{ c.name }}</span>
     <span class="contact-phone text-xl text-gray-700 mr-6">{{ c.telephone }}</span>
     <div class="flex items-center space-x-4">
-      <a href="{{ url_for('main.edit', index=loop.index0) }}" class="text-sm text-blue-600 hover:underline">Bewerk</a>
-      <form class="delete-form inline-flex items-center space-x-1" action="{{ url_for('main.delete', index=loop.index0) }}" method="post">
+      <a href="{{ url_for('main.edit', contact_id=c.id) }}" class="text-sm text-blue-600 hover:underline">Bewerk</a>
+      <form class="delete-form inline-flex items-center space-x-1" action="{{ url_for('main.delete', contact_id=c.id) }}" method="post">
 
         <svg class="delete-btn icon-btn text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Verwijder">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" />

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask>=2.0
+Flask-SQLAlchemy
 Gunicorn
 pytest
 beautifulsoup4

--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -1,50 +1,64 @@
 import os
+import sys
 import tempfile
 import io
 import pytest
 from bs4 import BeautifulSoup
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from app import create_app
-from app.models import load_phonebook
+from app.models import Contact, init_db, db
+
 
 @pytest.fixture
 def client():
     tmpdir = tempfile.TemporaryDirectory()
-    app = create_app({'TESTING': True, 'PHONEBOOK_PATH': os.path.join(tmpdir.name, 'pb.xml'), 'SECRET_KEY': 'test'})
+    db_path = os.path.join(tmpdir.name, 'test.db')
+    app = create_app({
+        'TESTING': True,
+        'PHONEBOOK_PATH': os.path.join(tmpdir.name, 'pb.xml'),
+        'SECRET_KEY': 'test',
+        'SQLALCHEMY_DATABASE_URI': f'sqlite:///{db_path}'
+    })
+    with app.app_context():
+        init_db()
     with app.test_client() as client:
         yield client
     tmpdir.cleanup()
 
+
 def test_add_and_delete(client):
-    # add first contact
     response = client.post('/add', data={'name': 'John', 'telephone': '+31 6 28330622'}, follow_redirects=True)
     assert response.status_code == 200
     assert b'John' in response.data
 
-    # add second contact
     response = client.post('/add', data={'name': 'Jane', 'telephone': '+31 6 11111111'}, follow_redirects=True)
     assert response.status_code == 200
     assert b'Jane' in response.data and b'John' in response.data
 
-    # delete contact "Jane" by finding its sorted index
-    path = client.application.config['PHONEBOOK_PATH']
-    contacts = load_phonebook(path)
-    jane_index = next(i for i, c in enumerate(contacts) if c['name'] == 'Jane')
-    response = client.post(f'/delete/{jane_index}', follow_redirects=True)
+    with client.application.app_context():
+        jane_id = Contact.query.filter_by(name='Jane').first().id
+    response = client.post(f'/delete/{jane_id}', follow_redirects=True)
     assert b'Jane' not in response.data
     assert b'John' in response.data
 
 
 def test_edit_contact(client):
     client.post('/add', data={'name': 'Jane', 'telephone': '+31 6 11111111'})
-    # edit contact
-    response = client.post('/edit/0', data={'name': 'Janet', 'telephone': '+31 6 22222222'}, follow_redirects=True)
+    with client.application.app_context():
+        contact_id = Contact.query.filter_by(name='Jane').first().id
+    response = client.post(
+        f'/edit/{contact_id}',
+        data={'name': 'Janet', 'telephone': '+31 6 22222222'},
+        follow_redirects=True,
+    )
     assert response.status_code == 200
     assert b'Janet' in response.data
 
+
 def test_edit_out_of_range(client):
     client.post('/add', data={'name': 'Test', 'telephone': '+31 6 12345678'})
-    # attempt to edit non-existent contact should 404
-    response = client.get('/edit/5')
+    response = client.get('/edit/999')
     assert response.status_code == 404
 
 
@@ -57,24 +71,22 @@ def test_import_contacts(client):
     assert response.status_code == 200
     assert b'John' in response.data and b'Jane' in response.data
 
+
 def test_invalid_add_contact(client):
-    # missing name and invalid phone number
     response = client.post('/add', data={'name': '', 'telephone': 'abc'}, follow_redirects=True)
     assert response.status_code == 200
     assert b'Naam is verplicht.' in response.data
     assert b'Ongeldig telefoonnummer.' in response.data
-    # no contacts should have been added
     response = client.get('/')
     assert b'abc' not in response.data
 
+
 def test_delete_out_of_range(client):
-    # add one valid contact
     client.post('/add', data={'name': 'Single', 'telephone': '+31 6 00000000'})
-    # attempt to delete non-existent index
-    response = client.post('/delete/5', follow_redirects=True)
+    response = client.post('/delete/999', follow_redirects=True)
     assert response.status_code == 200
-    # contact should still exist
     assert b'Single' in response.data
+
 
 def test_import_with_invalid_rows(client):
     csv_data = "name,telephone\nValid,+31611111111\nBad,abc\nAnother,+31622222222"
@@ -83,7 +95,6 @@ def test_import_with_invalid_rows(client):
     }
     response = client.post('/import', data=data, follow_redirects=True)
     assert response.status_code == 200
-    # only valid rows should be imported
     assert b'Valid' in response.data and b'Another' in response.data
     assert b'Bad' not in response.data
 
@@ -96,13 +107,14 @@ def test_health_endpoint(client):
 
 def test_delete_via_delete_method(client):
     client.post('/add', data={'name': 'Temp', 'telephone': '+31 6 99999999'})
-    path = client.application.config['PHONEBOOK_PATH']
-    contacts = load_phonebook(path)
-    index = next(i for i, c in enumerate(contacts) if c['name'] == 'Temp')
-    response = client.delete(f'/delete/{index}')
+    with client.application.app_context():
+        contact = Contact.query.filter_by(name='Temp').first()
+        contact_id = contact.id
+        count_before = Contact.query.count()
+    response = client.delete(f'/delete/{contact_id}')
     assert response.status_code == 204
-    contacts_after = load_phonebook(path)
-    assert len(contacts_after) == len(contacts) - 1
+    with client.application.app_context():
+        assert Contact.query.count() == count_before - 1
 
 
 def _search_items(html, query):
@@ -122,3 +134,4 @@ def test_search_ignores_action_text(client):
     resp = client.get('/')
     matches = _search_items(resp.data.decode('utf-8'), 'b')
     assert len(matches) == 0
+


### PR DESCRIPTION
## Summary
- Replace XML phonebook helpers with SQLAlchemy `Contact` model and `init_db` routine that imports existing `phonebook.xml`
- Configure database in app factory, add `init-db` CLI, and serve `/phonebook.xml` from stored contacts
- Update routes, templates, and tests to use database-backed contacts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ce86e4a18832ca2d3bf9b0c860ec2