### PR TITLE
Document health-check tooling review

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install system dependencies needed for health checks.
-# TODO: Consider installing curl only in a dedicated healthcheck container or using a lighter alternative.
+# See TODO.md: Evaluate lighter health-check tooling to avoid installing curl in production images.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+* Evaluate lighter health-check tooling to avoid installing `curl` in production images.


### PR DESCRIPTION
## Summary
- Add TODO entry to evaluate lighter health-check tooling instead of installing curl in production images
- Reference TODO entry from Dockerfile in place of inline comment

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ceed9f4bc832c94e0a95204452933