### PR TITLE
Style flash messages by category

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,8 +10,14 @@
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
       <ul class="mb-4">
+        {% set classes = {
+          'info': 'text-green-600',
+          'error': 'text-red-600',
+          'warning': 'text-yellow-600',
+          'success': 'text-green-600'
+        } %}
         {% for category, message in messages %}
-        <li class="text-red-600">{{ message }}</li>
+        <li class="{{ classes.get(category, 'text-red-600') }}">{{ message }}</li>
         {% endfor %}
       </ul>
       {% endif %}

--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -67,6 +67,24 @@ def test_invalid_add_contact(client):
     response = client.get('/')
     assert b'abc' not in response.data
 
+
+def test_flash_message_styling(client):
+    # trigger error flash
+    resp = client.post('/import', data={}, follow_redirects=True)
+    soup = BeautifulSoup(resp.data, 'html.parser')
+    li = soup.select_one('ul li')
+    assert 'text-red-600' in li.get('class', [])
+
+    # trigger info flash
+    csv_data = "name,telephone\nJohn,+31611111111"
+    data = {
+        'file': (io.BytesIO(csv_data.encode('utf-8')), 'contacts.csv'),
+    }
+    resp = client.post('/import', data=data, follow_redirects=True)
+    soup = BeautifulSoup(resp.data, 'html.parser')
+    li = soup.select_one('ul li')
+    assert 'text-green-600' in li.get('class', [])
+
 def test_delete_out_of_range(client):
     # add one valid contact
     client.post('/add', data={'name': 'Single', 'telephone': '+31 6 00000000'})


### PR DESCRIPTION
## Summary
- Style flash messages in `base.html` with Tailwind classes based on category
- Test flash message styling for `info` and `error` categories

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf1e08608832c9210d10727a5a497