### PR TITLE
Store phonebook contacts in database

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask>=2.0
 Gunicorn
 pytest
 beautifulsoup4
+SQLAlchemy


### PR DESCRIPTION
## Summary
- replace XML storage with SQLAlchemy `Contact` table and database-backed CRUD helpers
- serve phonebook XML dynamically from the database using ElementTree
- adjust routes and tests for the new database workflow and add SQLAlchemy dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf559d47c832ca523889d1f58842f