### PR TITLE
feat: structured XML exports and alembic setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yealink Phonebook Server
 
-Deze applicatie biedt een webinterface om een Yealink telefoonboek te beheren. Contacten kunnen worden toegevoegd of verwijderd via de browser en worden opgeslagen in `phonebook.xml` in het Yealink-formaat. De gebruikersinterface is opgezet met **Tailwind CSS** voor een moderne uitstraling zonder extra build-stap.
+Deze applicatie biedt een webinterface om een Yealink telefoonboek te beheren. De gegevens worden opgeslagen in een SQLite-database; de Yealink-XML-bestanden zijn slechts een export van deze database. De gebruikersinterface is opgezet met **Tailwind CSS** voor een moderne uitstraling zonder extra build-stap.
 
 ## Installatie
 
@@ -18,7 +18,7 @@ python run.py
 
 ## Gebruik
 
-Bezoek `http://localhost:8080` voor een lijst van contacten. Gebruik de knop **Nieuwe contact** om een contact toe te voegen. Elk contact heeft een naam en nummer. Bestaande contacten kun je via de link **Bewerk** aanpassen. Wijzigingen worden direct opgeslagen in `phonebook.xml`.
+Bezoek `http://localhost:8080` voor een lijst van contacten. Gebruik de knop **Nieuwe contact** om een contact toe te voegen. Elk contact heeft een naam en nummer. Bestaande contacten kun je via de link **Bewerk** aanpassen. Wijzigingen worden direct in de database opgeslagen en de XML-exports worden automatisch hieruit gegenereerd.
 
 Via de knop **Importeer CSV** kun je meerdere contacten ineens toevoegen. Upload
 een CSV-bestand met kolommen `name` en `telephone`. Alleen rijen met geldige waarden worden toegevoegd.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,40 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:////data/app.db
+
+offline = false
+
+dialect = sqlite
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,7 @@ class Contact(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     telephone = Column(String, nullable=False)
+    category = Column(String, nullable=False, default='other')
 
 
 def _get_session():
@@ -29,9 +30,9 @@ def load_phonebook():
     return result
 
 
-def add_contact(name, telephone):
+def add_contact(name, telephone, category='other'):
     session = _get_session()
-    session.add(Contact(name=name, telephone=telephone))
+    session.add(Contact(name=name, telephone=telephone, category=category))
     session.commit()
     session.close()
 
@@ -48,13 +49,14 @@ def delete_contact(index):
     return False
 
 
-def update_contact(index, name, telephone):
+def update_contact(index, name, telephone, category='other'):
     session = _get_session()
     contacts = session.query(Contact).order_by(Contact.name).all()
     if 0 <= index < len(contacts):
         contact = contacts[index]
         contact.name = name
         contact.telephone = telephone
+        contact.category = category
         session.commit()
         session.close()
         return True
@@ -62,7 +64,7 @@ def update_contact(index, name, telephone):
     return False
 
 
-def import_contacts(fileobj, validator):
+def import_contacts(fileobj, validator, category='other'):
     session = _get_session()
     reader = csv.DictReader(fileobj)
     added = 0
@@ -70,7 +72,7 @@ def import_contacts(fileobj, validator):
         name = row.get('name') or row.get('Name')
         telephone = row.get('telephone') or row.get('Telephone')
         if validator(name, telephone):
-            session.add(Contact(name=name, telephone=telephone))
+            session.add(Contact(name=name, telephone=telephone, category=category))
             added += 1
     if added:
         session.commit()
@@ -80,7 +82,7 @@ def import_contacts(fileobj, validator):
     return added
 
 
-def import_contacts_xml(fileobj, validator):
+def import_contacts_xml(fileobj, validator, category='other'):
     session = _get_session()
     tree = ET.parse(fileobj)
     root = tree.getroot()
@@ -89,7 +91,7 @@ def import_contacts_xml(fileobj, validator):
         name = entry.findtext('Name')
         telephone = entry.findtext('Telephone')
         if validator(name, telephone):
-            session.add(Contact(name=name, telephone=telephone))
+            session.add(Contact(name=name, telephone=telephone, category=category))
             added += 1
     if added:
         session.commit()

--- a/app/routes_xml.py
+++ b/app/routes_xml.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from hashlib import md5
+from datetime import datetime, timezone
+from email.utils import format_datetime, parsedate_to_datetime
+from flask import Blueprint, Response, current_app, request, url_for
+import xml.etree.ElementTree as ET
+import os
+
+from .models import Contact
+
+xml_bp = Blueprint('xml', __name__, url_prefix='/phonebook')
+
+
+def _db_timestamp() -> datetime:
+    db_path = current_app.config['DB_PATH']
+    return datetime.fromtimestamp(os.path.getmtime(db_path), tz=timezone.utc)
+
+
+def _xml_response(xml_bytes: bytes) -> Response:
+    etag = md5(xml_bytes).hexdigest()
+    last_modified = _db_timestamp()
+    headers = {
+        'ETag': etag,
+        'Last-Modified': format_datetime(last_modified, usegmt=True),
+        'Content-Type': 'application/xml',
+    }
+    if request.headers.get('If-None-Match') == etag:
+        return Response(status=304, headers=headers)
+    ims = request.headers.get('If-Modified-Since')
+    if ims:
+        try:
+            ims_dt = parsedate_to_datetime(ims)
+            if ims_dt >= last_modified.replace(microsecond=0):
+                return Response(status=304, headers=headers)
+        except Exception:
+            pass
+    return Response(xml_bytes, headers=headers)
+
+
+@xml_bp.route('/root.xml')
+def root_xml() -> Response:
+    root = ET.Element('YealinkIPPhoneDirectory')
+    items = [
+        ('All', url_for('xml.all_xml', _external=False)),
+        ('Practices', url_for('xml.practices_xml', _external=False)),
+        ('Suppliers', url_for('xml.suppliers_xml', _external=False)),
+    ]
+    for name, url in items:
+        mi = ET.SubElement(root, 'MenuItem')
+        ET.SubElement(mi, 'Name').text = name
+        ET.SubElement(mi, 'URL').text = url
+    xml_bytes = ET.tostring(root, encoding='utf-8', xml_declaration=True)
+    return _xml_response(xml_bytes)
+
+
+def _contacts_xml(category: str | None = None) -> bytes:
+    session = current_app.config['SESSION_FACTORY']()
+    query = session.query(Contact)
+    if category:
+        query = query.filter(Contact.category == category)
+    contacts = query.order_by(Contact.name).all()
+    session.close()
+    root = ET.Element('YealinkIPPhoneDirectory')
+    for c in contacts:
+        entry = ET.SubElement(root, 'DirectoryEntry')
+        ET.SubElement(entry, 'Name').text = c.name
+        ET.SubElement(entry, 'Telephone').text = c.telephone
+    return ET.tostring(root, encoding='utf-8', xml_declaration=True)
+
+
+@xml_bp.route('/all.xml')
+def all_xml() -> Response:
+    return _xml_response(_contacts_xml())
+
+
+@xml_bp.route('/practices.xml')
+def practices_xml() -> Response:
+    return _xml_response(_contacts_xml('practice'))
+
+
+@xml_bp.route('/suppliers.xml')
+def suppliers_xml() -> Response:
+    return _xml_response(_contacts_xml('supplier'))

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,35 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+import os
+
+from app.models import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,16 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ''}
+
+def upgrade() -> None:
+    ${upgrades if upgrades else 'pass'}
+
+def downgrade() -> None:
+    ${downgrades if downgrades else 'pass'}

--- a/migrations/versions/0001_initial.py
+++ b/migrations/versions/0001_initial.py
@@ -1,0 +1,20 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'contacts',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('telephone', sa.String(), nullable=False),
+        sa.Column('category', sa.String(), nullable=False, server_default='other'),
+    )
+
+def downgrade() -> None:
+    op.drop_table('contacts')

--- a/phonebook.xml
+++ b/phonebook.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<YealinkIPPhoneDirectory/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Gunicorn
 pytest
 beautifulsoup4
 SQLAlchemy
+alembic


### PR DESCRIPTION
## Summary
- document database as source of truth instead of XML
- introduce Alembic with initial contacts schema
- add Yealink XML endpoints with caching headers
- remove legacy phonebook.xml from repository

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689da60c8a20832caac117c47a2f4c64