### PR TITLE
Add JSON API, CSV/VCF exports, categories, and Docker volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,6 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install system dependencies needed for health checks.
-# See TODO.md: Evaluate lighter health-check tooling to avoid installing curl in production images.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
-
 # Install Python dependencies separately for better caching.
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yealink Phonebook Server
 
-Deze applicatie biedt een webinterface om een Yealink telefoonboek te beheren. De gegevens worden opgeslagen in een SQLite-database; de Yealink-XML-bestanden zijn slechts een export van deze database. De gebruikersinterface is opgezet met **Tailwind CSS** voor een moderne uitstraling zonder extra build-stap.
+Deze applicatie biedt een webinterface om een Yealink telefoonboek te beheren. De SQLite-database is de enige bron van waarheid; hieruit worden Yealink XML-bestanden, CSV en VCF on‑demand gegenereerd. De gebruikersinterface is opgezet met **Tailwind CSS** voor een moderne uitstraling zonder extra build-stap.
 
 ## Installatie
 
@@ -20,19 +20,33 @@ python run.py
 
 Bezoek `http://localhost:8080` voor een lijst van contacten. Gebruik de knop **Nieuwe contact** om een contact toe te voegen. Elk contact heeft een naam en nummer. Bestaande contacten kun je via de link **Bewerk** aanpassen. Wijzigingen worden direct in de database opgeslagen en de XML-exports worden automatisch hieruit gegenereerd.
 
-Via de knop **Importeer CSV** kun je meerdere contacten ineens toevoegen. Upload
-een CSV-bestand met kolommen `name` en `telephone`. Alleen rijen met geldige waarden worden toegevoegd.
+Via de knop **Importeer CSV** kun je meerdere contacten ineens toevoegen. Upload een CSV-bestand met kolommen `name` en `telephone`. Alleen rijen met geldige waarden worden toegevoegd. Elk contact kan een categorie hebben: `practice`, `supplier` of `other`.
+
+### JSON API
+
+Een simpele JSON API is beschikbaar onder `/api/contacts`:
+
+* `GET /api/contacts` – lijst van contacten gesorteerd op naam
+* `POST /api/contacts` – maak een nieuw contact (`name`, `telephone`, optioneel `category`)
+* `PUT /api/contacts/<id>` – update bestaand contact
+* `DELETE /api/contacts/<id>` – verwijder contact
+
+### Export
+
+Naast de Yealink XML is er export naar CSV en VCF:
+
+* `GET /export/contacts.csv`
+* `GET /export/contacts.vcf`
 
 ## Docker Deployment
 
-De meegeleverde `Dockerfile` bouwt een image dat via Gunicorn op poort 8080 draait. Build en start bijvoorbeeld met:
+Gebruik de meegeleverde `docker-compose.yml` om de database te bewaren op een volume en een Python-based healthcheck te gebruiken:
 
 ```bash
-docker build -t phonebook .
-docker run -p 8080:8080 phonebook
+docker compose up --build
 ```
 
-Dit is gemakkelijk te deployen via Portainer of de CLI op een Synology NAS.
+De compose-file mount `./data` als volume zodat `phonebook.db` bewaard blijft tussen container herstarts. Voor een eenmalige import kan een legacy Yealink XML worden gemount en het pad via `INITIAL_PHONEBOOK_XML` worden doorgegeven.
 
 ## Tests
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,9 +2,12 @@ from flask import Flask, Response
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from pathlib import Path
+import os
 
 from .routes import main_bp
 from .routes_xml import xml_bp
+from .routes_api import api_bp
+from .routes_export import export_bp
 from .models import Base, Contact, import_contacts_xml
 from .utils import PHONE_RE
 
@@ -13,7 +16,8 @@ def create_app(test_config=None):
     default_db = Path(__file__).resolve().parents[1] / "phonebook.db"
     app.config.from_mapping(
         SECRET_KEY='dev',
-        SQLALCHEMY_DATABASE_URI=f'sqlite:///{default_db}'
+        SQLALCHEMY_DATABASE_URI=os.environ.get('SQLALCHEMY_DATABASE_URI', f'sqlite:///{default_db}'),
+        INITIAL_PHONEBOOK_XML=os.environ.get('INITIAL_PHONEBOOK_XML', '/data/phonebook.xml'),
     )
 
     if test_config:
@@ -48,6 +52,8 @@ def create_app(test_config=None):
 
     app.register_blueprint(main_bp)
     app.register_blueprint(xml_bp)
+    app.register_blueprint(api_bp)
+    app.register_blueprint(export_bp)
 
     @app.route("/health", methods=["GET"])
     def health():

--- a/app/models.py
+++ b/app/models.py
@@ -25,7 +25,15 @@ def load_phonebook():
     """Return all contacts ordered by name as a list of dicts."""
     session = _get_session()
     contacts = session.query(Contact).order_by(Contact.name).all()
-    result = [{'name': c.name, 'telephone': c.telephone} for c in contacts]
+    result = [
+        {
+            'id': c.id,
+            'name': c.name,
+            'telephone': c.telephone,
+            'category': c.category,
+        }
+        for c in contacts
+    ]
     session.close()
     return result
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -16,8 +16,9 @@ def add():
     if request.method == 'POST':
         name = request.form.get('name')
         telephone = request.form.get('telephone')
+        category = request.form.get('category', 'other')
         if validate_contact(name, telephone):
-            add_contact(name, telephone)
+            add_contact(name, telephone, category)
             return redirect(url_for('main.index'))
     return render_template('add.html')
 
@@ -40,8 +41,9 @@ def edit(index):
     if request.method == 'POST':
         name = request.form.get('name')
         telephone = request.form.get('telephone')
+        category = request.form.get('category', 'other')
         if validate_contact(name, telephone):
-            update_contact(index, name, telephone)
+            update_contact(index, name, telephone, category)
             return redirect(url_for('main.index'))
     contact = contacts[index]
     return render_template('edit.html', contact=contact, index=index)

--- a/app/routes_api.py
+++ b/app/routes_api.py
@@ -1,0 +1,99 @@
+from flask import Blueprint, request, jsonify, current_app
+
+from .models import Contact
+from .utils import validate_contact_data
+
+
+api_bp = Blueprint('api', __name__, url_prefix='/api/contacts')
+
+
+def _session():
+    return current_app.config['SESSION_FACTORY']()
+
+
+@api_bp.get('')
+@api_bp.get('/')  # allow trailing slash
+
+def list_contacts():
+    session = _session()
+    contacts = session.query(Contact).order_by(Contact.name).all()
+    result = [
+        {
+            'id': c.id,
+            'name': c.name,
+            'telephone': c.telephone,
+            'category': c.category,
+        }
+        for c in contacts
+    ]
+    session.close()
+    return jsonify(result)
+
+
+@api_bp.post('')
+@api_bp.post('/')
+
+def create_contact():
+    data = request.get_json(silent=True) or {}
+    name = data.get('name')
+    telephone = data.get('telephone')
+    category = data.get('category', 'other')
+    valid, messages = validate_contact_data(name, telephone)
+    if not valid:
+        return jsonify({'error': messages[0]}), 400
+    session = _session()
+    contact = Contact(name=name, telephone=telephone, category=category)
+    session.add(contact)
+    session.commit()
+    result = {
+        'id': contact.id,
+        'name': contact.name,
+        'telephone': contact.telephone,
+        'category': contact.category,
+    }
+    session.close()
+    return jsonify(result), 201
+
+
+@api_bp.put('/<int:contact_id>')
+
+def update_contact(contact_id):
+    data = request.get_json(silent=True) or {}
+    session = _session()
+    contact = session.get(Contact, contact_id)
+    if not contact:
+        session.close()
+        return jsonify({'error': 'Not found'}), 404
+    name = data.get('name', contact.name)
+    telephone = data.get('telephone', contact.telephone)
+    category = data.get('category', contact.category)
+    valid, messages = validate_contact_data(name, telephone)
+    if not valid:
+        session.close()
+        return jsonify({'error': messages[0]}), 400
+    contact.name = name
+    contact.telephone = telephone
+    contact.category = category
+    session.commit()
+    result = {
+        'id': contact.id,
+        'name': contact.name,
+        'telephone': contact.telephone,
+        'category': contact.category,
+    }
+    session.close()
+    return jsonify(result)
+
+
+@api_bp.delete('/<int:contact_id>')
+
+def delete_contact(contact_id):
+    session = _session()
+    contact = session.get(Contact, contact_id)
+    if not contact:
+        session.close()
+        return jsonify({'error': 'Not found'}), 404
+    session.delete(contact)
+    session.commit()
+    session.close()
+    return ('', 204)

--- a/app/routes_export.py
+++ b/app/routes_export.py
@@ -1,0 +1,52 @@
+from flask import Blueprint, Response, current_app
+
+from .models import Contact
+
+
+export_bp = Blueprint('export', __name__, url_prefix='/export')
+
+
+def _session():
+    return current_app.config['SESSION_FACTORY']()
+
+
+@export_bp.route('/contacts.csv')
+def export_csv():
+    session = _session()
+    contacts = session.query(Contact).order_by(Contact.name).all()
+    session.close()
+
+    def generate():
+        yield 'name,telephone,category\n'
+        for c in contacts:
+            yield f'{c.name},{c.telephone},{c.category}\n'
+
+    headers = {
+        'Content-Disposition': 'attachment; filename=contacts.csv'
+    }
+    return Response(generate(), mimetype='text/csv', headers=headers)
+
+
+@export_bp.route('/contacts.vcf')
+def export_vcf():
+    session = _session()
+    contacts = session.query(Contact).order_by(Contact.name).all()
+    session.close()
+
+    def generate():
+        for c in contacts:
+            parts = c.name.split(' ', 1)
+            first = parts[0]
+            last = parts[1] if len(parts) > 1 else ''
+            full = c.name
+            yield 'BEGIN:VCARD\n'
+            yield 'VERSION:3.0\n'
+            yield f'N:{last};{first}\n'
+            yield f'FN:{full}\n'
+            yield f'TEL;TYPE=CELL:{c.telephone}\n'
+            yield 'END:VCARD\n'
+
+    headers = {
+        'Content-Disposition': 'attachment; filename=contacts.vcf'
+    }
+    return Response(generate(), mimetype='text/vcard', headers=headers)

--- a/app/templates/add.html
+++ b/app/templates/add.html
@@ -13,6 +13,14 @@
     <label class="block mb-1">Nummer</label>
     <input class="w-full border p-2 rounded" type="text" name="telephone">
   </div>
+  <div>
+    <label class="block mb-1">Categorie</label>
+    <select class="w-full border p-2 rounded" name="category">
+      <option value="practice">practice</option>
+      <option value="supplier">supplier</option>
+      <option value="other" selected>other</option>
+    </select>
+  </div>
   <button class="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600" type="submit">Opslaan</button>
 </form>
 <a class="inline-block mt-4 text-blue-500 hover:underline" href="{{ url_for('main.index') }}">Terug</a>

--- a/app/templates/edit.html
+++ b/app/templates/edit.html
@@ -13,6 +13,14 @@
     <label class="block mb-1">Nummer</label>
     <input class="w-full border p-2 rounded" type="text" name="telephone" value="{{ contact.telephone }}">
   </div>
+  <div>
+    <label class="block mb-1">Categorie</label>
+    <select class="w-full border p-2 rounded" name="category">
+      <option value="practice" {% if contact.category == 'practice' %}selected{% endif %}>practice</option>
+      <option value="supplier" {% if contact.category == 'supplier' %}selected{% endif %}>supplier</option>
+      <option value="other" {% if contact.category == 'other' %}selected{% endif %}>other</option>
+    </select>
+  </div>
   <button class="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600" type="submit">Opslaan</button>
 </form>
 <a class="inline-block mt-4 text-blue-500 hover:underline" href="{{ url_for('main.index') }}">Terug</a>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,6 +22,7 @@
   {% for c in contacts %}
   <div class="contact-item fade-slide flex items-center px-6 py-4" data-index="{{ loop.index0 }}">
     <span class="contact-name flex-1 text-xl font-medium text-gray-900">{{ c.name }}</span>
+    <span class="contact-category text-sm text-gray-500 mr-4">{{ c.category }}</span>
     <span class="contact-phone text-xl text-gray-700 mr-6">{{ c.telephone }}</span>
     <div class="flex items-center space-x-4">
       <a href="{{ url_for('main.edit', index=loop.index0) }}" class="text-sm text-blue-600 hover:underline">Bewerk</a>

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,17 +6,33 @@ from flask import flash
 PHONE_RE = re.compile(r'^\+?[0-9 ]+$')
 
 
-def validate_contact(name, telephone):
-    valid = True
+def validate_contact_data(name: str | None, telephone: str | None):
+    """Validate a contact and return ``(valid, messages)``.
+
+    ``messages`` is a list of error strings.  This helper performs the actual
+    validation without flashing so it can be reused by the JSON API.
+    """
+
+    messages: list[str] = []
     if not name:
-        flash('Naam is verplicht.', 'error')
-        valid = False
+        messages.append('Naam is verplicht.')
     if not telephone or not PHONE_RE.match(telephone):
-        flash('Ongeldig telefoonnummer.', 'error')
-        valid = False
+        messages.append('Ongeldig telefoonnummer.')
     else:
         digits = telephone.replace(' ', '').lstrip('+')
         if not digits.isdigit() or len(digits) > 15:
-            flash('Ongeldig telefoonnummer.', 'error')
-            valid = False
+            messages.append('Ongeldig telefoonnummer.')
+    return (len(messages) == 0, messages)
+
+
+def validate_contact(name: str | None, telephone: str | None) -> bool:
+    """UI validator that flashes messages on failure.
+
+    Returns ``True`` when the contact details are valid.
+    """
+
+    valid, messages = validate_contact_data(name, telephone)
+    if not valid:
+        for msg in messages:
+            flash(msg, 'error')
     return valid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,15 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./phonebook.xml:/app/phonebook.xml
+      - ./data:/app/data
+      # Optional: mount a legacy phonebook XML for one-time import
+      # - ./phonebook.xml:/app/phonebook.xml
+    environment:
+      - SQLALCHEMY_DATABASE_URI=sqlite:////app/data/phonebook.db
+      # Optional one-time import path
+      - INITIAL_PHONEBOOK_XML=/app/phonebook.xml
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+      test: ["CMD-SHELL", "python - <<'PY'\nimport urllib.request,sys\nu='http://localhost:8080/health'\ntry:\n  urllib.request.urlopen(u, timeout=5)\nexcept Exception:\n  sys.exit(1)\nprint('ok')\nPY"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import tempfile
+import pytest
+
+# Ensure application importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+
+@pytest.fixture
+def client():
+    tmpdir = tempfile.TemporaryDirectory()
+    db_path = os.path.join(tmpdir.name, 'pb.sqlite')
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': f'sqlite:///{db_path}', 'SECRET_KEY': 'test'})
+    with app.test_client() as client:
+        yield client
+    tmpdir.cleanup()
+
+
+def test_api_crud(client):
+    # Create
+    resp = client.post('/api/contacts', json={'name': 'Bob', 'telephone': '+31612345678', 'category': 'practice'})
+    assert resp.status_code == 201
+    data = resp.get_json()
+    cid = data['id']
+    assert data['category'] == 'practice'
+
+    # List
+    resp = client.get('/api/contacts')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert any(c['id'] == cid for c in data)
+
+    # Update
+    resp = client.put(f'/api/contacts/{cid}', json={'telephone': '+31699999999', 'category': 'supplier'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['telephone'] == '+31699999999'
+    assert data['category'] == 'supplier'
+
+    # Delete
+    resp = client.delete(f'/api/contacts/{cid}')
+    assert resp.status_code == 204
+    # Ensure gone
+    resp = client.get('/api/contacts')
+    data = resp.get_json()
+    assert all(c['id'] != cid for c in data)
+
+    # 404 paths
+    assert client.put('/api/contacts/999', json={'name': 'x'}).status_code == 404
+    assert client.delete('/api/contacts/999').status_code == 404

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+
+@pytest.fixture
+def client():
+    tmpdir = tempfile.TemporaryDirectory()
+    db_path = os.path.join(tmpdir.name, 'pb.sqlite')
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': f'sqlite:///{db_path}', 'SECRET_KEY': 'test'})
+    with app.test_client() as client:
+        yield client
+    tmpdir.cleanup()
+
+
+def test_csv_export(client):
+    client.post('/add', data={'name': 'Alice', 'telephone': '+311', 'category': 'practice'})
+    client.post('/add', data={'name': 'Bob', 'telephone': '+322', 'category': 'supplier'})
+    resp = client.get('/export/contacts.csv')
+    assert resp.status_code == 200
+    text = resp.data.decode('utf-8').strip().splitlines()
+    assert text[0] == 'name,telephone,category'
+    assert len(text) == 3
+
+
+def test_vcf_export(client):
+    client.post('/add', data={'name': 'Alice Example', 'telephone': '+311'})
+    resp = client.get('/export/contacts.vcf')
+    assert resp.status_code == 200
+    data = resp.data.decode('utf-8')
+    assert 'FN:Alice Example' in data
+    assert 'TEL;TYPE=CELL:+311' in data
+
+
+def test_category_xml(client):
+    client.post('/add', data={'name': 'P1', 'telephone': '+111', 'category': 'practice'})
+    client.post('/add', data={'name': 'S1', 'telephone': '+222', 'category': 'supplier'})
+    resp = client.get('/phonebook/practices.xml')
+    root = ET.fromstring(resp.data)
+    names = [e.findtext('Name') for e in root.findall('DirectoryEntry')]
+    assert 'P1' in names and 'S1' not in names
+    resp = client.get('/phonebook/suppliers.xml')
+    root = ET.fromstring(resp.data)
+    names = [e.findtext('Name') for e in root.findall('DirectoryEntry')]
+    assert 'S1' in names and 'P1' not in names


### PR DESCRIPTION
## Summary
- add `/api/contacts` JSON CRUD API with phone validation
- stream CSV and VCF exports built from the database
- support contact categories through UI and XML exports
- remove curl from Dockerfile and add python healthcheck with persistent DB volume

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689db4a00c60832cb84a4cd99eaf126c