### PR TITLE
Add migration for active contact column

### DIFF
--- a/migrations/versions/0003_add_active_to_contacts.py
+++ b/migrations/versions/0003_add_active_to_contacts.py
@@ -1,0 +1,16 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('contacts', sa.Column('active', sa.Boolean(), nullable=False, server_default=sa.true()))
+
+
+def downgrade() -> None:
+    op.drop_column('contacts', 'active')


### PR DESCRIPTION
## Summary
- add Alembic migration adding `active` column to `contacts`

## Testing
- `PYTHONPATH=. alembic upgrade head`
- `sqlite3 /data/app.db '.schema contacts'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dd7155b44832c8a974e60e6a51f9e