### PR TITLE
Ensure migrations locate project modules and expose PYTHONPATH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       # - ./phonebook.xml:/app/phonebook.xml
     environment:
       - SQLALCHEMY_DATABASE_URI=sqlite:////app/data/phonebook.db
+      - PYTHONPATH=/app
       # Optional one-time import path
       - INITIAL_PHONEBOOK_XML=/app/phonebook.xml
     healthcheck:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -2,7 +2,9 @@ from logging.config import fileConfig
 from sqlalchemy import engine_from_config, pool
 from alembic import context
 import os
+import sys, pathlib
 
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from app.models import Base
 
 config = context.config


### PR DESCRIPTION
## Summary
- add PYTHONPATH in docker-compose phonebook service
- include project root on sys.path so Alembic migrations can import models

## Testing
- `make test`
- `docker-compose build` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*
- `docker-compose run --rm phonebook alembic upgrade head` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689ddc081d90832c802804de3d94965b