### PR TITLE
feat: load DB URL from env for Alembic

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -8,6 +8,10 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from app.models import Base
 
 config = context.config
+config.set_main_option(
+    "sqlalchemy.url",
+    os.environ.get("SQLALCHEMY_DATABASE_URI", "sqlite:////app/data/phonebook.db"),
+)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)


### PR DESCRIPTION
## Summary
- support configuring Alembic DB URL via SQLALCHEMY_DATABASE_URI env var

## Testing
- `make test`
- `docker-compose build` *(fails: command not found: docker-compose)*
- `docker-compose run --rm phonebook alembic upgrade head` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_689dde23e000832c85f415e3e60015bc