### PR TITLE
Support importing legacy XML phonebooks

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,6 +1,13 @@
 from flask import Blueprint, render_template, request, redirect, url_for, abort, flash, jsonify
 from io import TextIOWrapper
-from .models import load_phonebook, add_contact, delete_contact, update_contact, import_contacts
+from .models import (
+    load_phonebook,
+    add_contact,
+    delete_contact,
+    update_contact,
+    import_contacts,
+    import_contacts_xml,
+)
 from .utils import validate_contact
 
 main_bp = Blueprint('main', __name__)
@@ -66,8 +73,12 @@ def import_view():
     if request.method == 'POST':
         file = request.files.get('file')
         if file:
-            text_file = TextIOWrapper(file.stream, encoding='utf-8')
-            count = import_contacts(text_file, validate_contact)
+            text_file = TextIOWrapper(file.stream, encoding="utf-8")
+            filename = (file.filename or "").lower()
+            if filename.endswith(".xml"):
+                count = import_contacts_xml(text_file, validate_contact)
+            else:
+                count = import_contacts(text_file, validate_contact)
             if count:
                 flash(f"{count} contacten ge\u00efmporteerd.", "info")
             return redirect(url_for('main.index'))

--- a/tests/test_phonebook.py
+++ b/tests/test_phonebook.py
@@ -63,6 +63,24 @@ def test_import_contacts(client):
     assert response.status_code == 200
     assert b'John' in response.data and b'Jane' in response.data
 
+
+def test_import_legacy_xml(client):
+    xml_data = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<YealinkIPPhoneBook>"
+        "<Directory>"
+        "<Unit Name='John' Phone1='+31611111111'/>"
+        "<Unit Name='Jane' Phone1='+31622222222'/>"
+        "</Directory>"
+        "</YealinkIPPhoneBook>"
+    )
+    data = {
+        'file': (io.BytesIO(xml_data.encode('utf-8')), 'contacts.xml'),
+    }
+    response = client.post('/import', data=data, follow_redirects=True)
+    assert response.status_code == 200
+    assert b'John' in response.data and b'Jane' in response.data
+
 def test_invalid_add_contact(client):
     # missing name and invalid phone number
     response = client.post('/add', data={'name': '', 'telephone': 'abc'}, follow_redirects=True)


### PR DESCRIPTION
## Summary
- allow uploading legacy Yealink XML files and import them into the phonebook
- simplify XML importer to handle only the Yealink formats used in this project
- test importing XML via the UI

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ded4fb7ec832c91cd4e74f1dbe985