### PR TITLE
docs: expand README and add dev tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL=postgresql+psycopg://inventory:inventory@db:5432/inventory
+BACKEND_PORT=8000
+FRONTEND_PORT=3000
+KEYCLOAK_URL=http://localhost:8080
+KEYCLOAK_REALM=such-empty
+KEYCLOAK_CLIENT_ID=frontend
+KEYCLOAK_CLIENT_SECRET=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__/
 phonebook.xml
 phonebook.xml
 data/phonebook.db
+
+.env
+.env.*
+!.env.example

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,29 @@
-.PHONY: test
+.PHONY: up down logs fmt lint backend-migrate backend-seed test
+
+up:
+	docker compose up -d --build
+
+down:
+	docker compose down -v
+
+logs:
+	docker compose logs -f --tail=200
+
+backend-migrate:
+	docker compose exec backend alembic -c /app/alembic.ini upgrade head
+
+backend-seed:
+	docker compose exec backend python -m app.scripts.seed
+
+fmt:
+	ruff check backend --fix || true
+	black backend || true
+	oneslint --fix frontend || true
+
+lint:
+	ruff check backend
+	mypy backend
+	npx tsc -p frontend
 
 test:
 	pip install -r requirements.txt

--- a/changes/pr1-docs-compose-makefile.md
+++ b/changes/pr1-docs-compose-makefile.md
@@ -1,0 +1,3 @@
+- expand README with setup and Keycloak instructions
+- replace docker-compose with healthchecks and volumes
+- extend Makefile with common targets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,45 @@
-version: '3.8'
+version: "3.9"
 services:
-  phonebook:
-    build: .
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./data:/app/data
-      # Optional: mount a legacy phonebook XML for one-time import
-      # - ./phonebook.xml:/app/phonebook.xml
+  db:
+    image: postgres:16
     environment:
-      - SQLALCHEMY_DATABASE_URI=sqlite:////app/data/phonebook.db
-      - PYTHONPATH=/app
-      # Optional one-time import path
-      - INITIAL_PHONEBOOK_XML=/app/phonebook.xml
+      POSTGRES_USER: inventory
+      POSTGRES_PASSWORD: inventory
+      POSTGRES_DB: inventory
+    volumes:
+      - db_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "python - <<'PY'\nimport urllib.request,sys\nu='http://localhost:8080/health'\ntry:\n  urllib.request.urlopen(u, timeout=5)\nexcept Exception:\n  sys.exit(1)\nprint('ok')\nPY"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
+      test: ["CMD-SHELL", "pg_isready -U inventory -d inventory"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    restart: unless-stopped
 
+  backend:
+    build: ./backend
+    env_file: .env
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+    ports: ["8000:8000"]
+    restart: unless-stopped
+
+  frontend:
+    build: ./frontend
+    env_file: .env
+    depends_on: [backend]
+    ports: ["3000:3000"]
+    restart: unless-stopped
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    command: ["start-dev", "--http-port=8080"]
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports: ["8080:8080"]
+    restart: unless-stopped
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- detail local setup, environment vars, Keycloak, and Synology deployment in README
- replace docker-compose with healthchecks and named volumes
- extend Makefile with compose helpers, linting, and seeding targets

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad6eb0efbc832c97e762b6a269ac1d