### PR TITLE
chore: add GitHub Codespaces devcontainer (Python+Node+Postgres) and validation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "codespaces-dev",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": { "version": "3.11" },
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "forwardPorts": [3000, 8000],
+  "portsAttributes": {
+    "3000": { "label": "frontend" },
+    "8000": { "label": "backend" }
+  },
+  "containerEnv": {
+    "DATABASE_URL": "postgresql+psycopg://inventory:inventory@db:5432/inventory"
+  },
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.makefile-tools",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "charliermarsh.ruff"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/base:jammy
+    command: sleep infinity
+    volumes:
+      - ..:/workspaces:cached
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: inventory
+      POSTGRES_PASSWORD: inventory
+      POSTGRES_DB: inventory
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U inventory -d inventory"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Backend (Python) ---
+if [ -d "backend" ]; then
+  cd backend
+  python -m pip install --upgrade pip
+  if [ -f "pyproject.toml" ]; then
+    pip install -e ".[dev]" || pip install -e .
+  elif [ -f "requirements.txt" ]; then
+    pip install -r requirements.txt
+  else
+    pip install fastapi uvicorn[standard] "SQLAlchemy>=2" alembic psycopg[binary] pydantic pytest
+  fi
+  cd -
+fi
+
+# --- Frontend (Node) ---
+if [ -d "frontend" ]; then
+  cd frontend
+  if [ -f "package-lock.json" ]; then
+    npm ci
+  elif [ -f "package.json" ]; then
+    npm install
+  fi
+  cd -
+fi
+
+echo "✅ Dev container setup complete."

--- a/.github/workflows/devcontainer-validate.yml
+++ b/.github/workflows/devcontainer-validate.yml
@@ -1,0 +1,30 @@
+name: Devcontainer validate
+on:
+  pull_request:
+  push:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate devcontainer.json syntax
+        run: |
+          python - <<'PY'
+import json
+json.load(open('.devcontainer/devcontainer.json'))
+print("devcontainer.json OK")
+PY
+
+      - name: Validate docker compose syntax (if present)
+        run: |
+          if [ -f .devcontainer/docker-compose.yml ]; then
+            docker compose -f .devcontainer/docker-compose.yml config >/dev/null
+            echo "docker-compose OK"
+          else
+            echo "No docker-compose file"
+          fi
+
+      - name: Check setup.sh is executable
+        run: test -x .devcontainer/setup.sh

--- a/README.md
+++ b/README.md
@@ -91,3 +91,18 @@ make test
 ## License
 
 MIT
+
+## Run in GitHub Codespaces
+
+This repo contains a ready-to-use dev container.
+
+**Steps**
+1. Push your changes and open GitHub → Code → Codespaces → Create codespace on main.
+2. The container provisions Python 3.11 + Node 20 and a Postgres 16 sidecar.
+3. After the first boot, dependencies are auto-installed via `.devcontainer/setup.sh`.
+
+**Useful commands**
+- Backend: `cd backend && uvicorn app.main:app --reload --host 0.0.0.0 --port 8000`
+- Frontend: `cd frontend && npm run dev`
+- DB: available at `db:5432` (user/pass `inventory` / DB `inventory`)
+- Ports are forwarded: 8000 (backend), 3000 (frontend).


### PR DESCRIPTION
## Summary
- add Codespaces devcontainer with Python 3.11, Node 20, Postgres 16
- validate devcontainer configuration in CI
- document how to start backend and frontend in Codespaces

## Testing
- `python - <<'PY'
import json; json.load(open('.devcontainer/devcontainer.json')); print("json ok")
PY`
- `docker-compose -f .devcontainer/docker-compose.yml config >/dev/null && echo "docker-compose config ok"`
- `docker compose -f .devcontainer/docker-compose.yml config >/dev/null && echo "docker compose config ok"` *(fails: unknown shorthand flag: 'f' in -f)*
- `test -x .devcontainer/setup.sh && echo "setup.sh executable"`


------
https://chatgpt.com/codex/tasks/task_e_68ad72503194832cac3b88d21cafa484