### PR TITLE
chore: support standalone docker-compose in workflow

### DIFF
--- a/.github/workflows/devcontainer-validate.yml
+++ b/.github/workflows/devcontainer-validate.yml
@@ -20,7 +20,11 @@ PY
       - name: Validate docker compose syntax (if present)
         run: |
           if [ -f .devcontainer/docker-compose.yml ]; then
-            docker compose -f .devcontainer/docker-compose.yml config >/dev/null
+            if docker compose version >/dev/null 2>&1; then
+              docker compose -f .devcontainer/docker-compose.yml config >/dev/null
+            else
+              docker-compose -f .devcontainer/docker-compose.yml config >/dev/null
+            fi
             echo "docker-compose OK"
           else
             echo "No docker-compose file"


### PR DESCRIPTION
## Summary
- fall back to `docker-compose` if compose plugin is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad754ef9ec832cb71aaed4fd4ad0d3